### PR TITLE
Fix languages processing order

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,41 +3,39 @@ const through2 = require('through2');
 const File = require('vinyl');
 const path = require('path');
 
-var gutil = require('gulp-util');
-
 const DEFAULT_CONFIG = {
     primary: 'en',
     langs: ['en_AU'],
-    destMask: "{lang}/{bundle}.json",
-    process: function( properties, lang ) {
-        return JSON.stringify( properties );
+    destMask: '{lang}/{bundle}.json',
+    process: function(properties) {
+        return JSON.stringify(properties);
     }
 };
 
-const transform = function (config) {
-    return through2.obj(function (file, enc, next) {
+const transform = function(config) {
+    const options = Object.assign({}, DEFAULT_CONFIG, config);
 
-        options = Object.assign({}, DEFAULT_CONFIG, config );
+    const re = /^(.*)\/([^\/]+)_([a-z]{2}(_[A-Z]{2})?).properties$/;
 
-        const primary = options.primary;
-        const langs = options.langs.map(function (lang) {
-            const order = [];
-            if (primary && lang.indexOf(primary) !== 0) {
-                order.push(primary);
-            }
-            order.push(lang.slice(0, 2));
-            if (lang.length === 5) {
-                order.push(lang);
-            }
-            return {
-                key: lang,
-                order: order
-            };
-        });
+    const primary = options.primary;
+    const langs = options.langs.map(function(lang) {
+        const order = [];
+        if (primary && lang.indexOf(primary) !== 0) {
+            order.push(primary);
+        }
+        order.push(lang.slice(0, 2));
+        if (lang.length === 5) {
+            order.push(lang);
+        }
+        return {
+            key: lang,
+            order: order
+        };
+    });
 
-        const bundles = {};
-        const re = /^(.*)\/([^\/]+)_([a-z]{2}(_[A-Z]{2})?).properties$/;
+    const bundles = {};
 
+    function bufferContents(file, enc, next) {
         const properties = parser.parse(file.contents);
         const parts = file.path.match(re);
         const bundleId = parts[2];
@@ -46,40 +44,42 @@ const transform = function (config) {
         bundles[bundleId] = bundles[bundleId] || {};
         bundles[bundleId][lang] = properties;
 
-        const bundleIds = Object.keys(bundles);
+        next();
+    }
 
+    function endStream(cb) {
+        const bundleIds = Object.keys(bundles);
         const updatedFiles = this;
 
-        bundleIds.forEach(function (bundleId) {
-            langs.forEach(function (lang) {
+        bundleIds.forEach(function(bundleId) {
+            langs.forEach(function(lang) {
                 const properties = {};
                 const bundle = bundles[bundleId];
 
-                lang.order.forEach(function (langRef) {
+                lang.order.forEach(function(langRef) {
                     if (langRef in bundle) {
-                        Object.keys(bundle[langRef]).forEach(function (k) {
+                        Object.keys(bundle[langRef]).forEach(function(k) {
                             properties[k] = bundle[langRef][k];
                         });
                     }
                 });
 
                 if (Object.keys(properties).length > 0) {
-                    const outPath = options.destMask.replace("{lang}", lang.key ).replace("{bundle}", bundleId );
-                    const outputFile = path.join(file.base, outPath);
+                    const outPath = options.destMask.replace('{lang}', lang.key).replace('{bundle}', bundleId);
 
                     const updatedFile = new File({
-                        base: file.base,
-                        path: outputFile,
-                        contents: new Buffer( options.process(properties, lang) )
+                        path: outPath,
+                        contents: new Buffer(options.process(properties, lang))
                     });
 
                     updatedFiles.push(updatedFile);
                 }
             });
         });
+        cb();
+    }
 
-        next();
-    });
+    return through2.obj(bufferContents, endStream);
 };
 
 module.exports = transform;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-i18n-properties",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "gulp plugin to convert java i18n property files to json",
   "author": "ui@aconex.com",
   "main": "index.js",


### PR DESCRIPTION
Two problems were fixed:
1. For "de_DE" language it was always output English translations to ".strings" files.
2. Did not take not translated keys from default ("en") bundle
